### PR TITLE
Set CATKIN_ENABLE_TESTING explicitely in make and test script

### DIFF
--- a/scripts/completion/test.sh
+++ b/scripts/completion/test.sh
@@ -40,9 +40,9 @@ function roswss_test() {
         roscd $package
 
         if [[ -z "$1" ]]; then
-            catkin build $package --catkin-make-args run_tests
+            catkin build $package -DCATKIN_ENABLE_TESTING=ON --catkin-make-args run_tests
         else
-            catkin build $package --catkin-make-args tests
+            catkin build $package -DCATKIN_ENABLE_TESTING=ON --catkin-make-args tests
         fi
 
         local launch

--- a/scripts/make.sh
+++ b/scripts/make.sh
@@ -14,8 +14,11 @@ if [ -z $build_cores ]; then
     build_cores=$(nproc --all)
 fi
 
+# Explicitely disable building the tests, because the variable CATKIN_ENABLE_TESTING is set to ON by default.
+#   Since it is added before the extra catkin args, it can be overwritten there.
+catkin_args=("-DCATKIN_ENABLE_TESTING=OFF")
+
 # check arguments
-catkin_args=()
 for var in "$@"; do
     case $var in
         debug)


### PR DESCRIPTION
Per default, CATKIN_ENABLE_TESTING is set to ON.

This leads to the tests always being built in the current make script, even when they are not executed. Additionally, test dependencies are required for the normal build.

With this change, the variable is set to OFF in the make script and set to ON in the test script.